### PR TITLE
allow passing options incompatible with gcc 4, tidy check_rtime

### DIFF
--- a/exception_lists/check_rtime
+++ b/exception_lists/check_rtime
@@ -215,16 +215,21 @@ OLDDEP		libw\.so\.1			# on297 build 7
 # would have to maintain two sets of mapfiles for each such object.
 # C++ use is rare in ON, so this is not worth pursuing.
 #
-NOSYMSORT	opt/SUNWdtrt/tst/common/pid/tst.weak2.exe	# DTrace test
-NOSYMSORT	lib/amd64/libnsl\.so\.1				# C++
-NOSYMSORT	lib/sparcv9/libnsl\.so\.1			# C++
-NOSYMSORT	lib/sparcv9/libfru\.so\.1			# C++
-NOSYMSORT	usr/lib/lms					# C++
-NOSYMSORT	ld\.so\.1					# libc_pic.a user
-NOSYMSORT	lib/libsun_fc\.so\.1				# C++
-NOSYMSORT	lib/amd64/libsun_fc\.so\.1			# C++
-NOSYMSORT	lib/sparcv9/libsun_fc\.so\.1 			# C++
-NOSYMSORT	usr/lib/amd64/libfru\.so\.1			# C++
+NOSYMSORT	ld\.so\.1				  # libc_pic.a user
+NOSYMSORT	lib/amd64/libnsl\.so\.1			  # C++
+NOSYMSORT	lib/amd64/libsun_fc\.so\.1		  # C++
+NOSYMSORT	lib/libsun_fc\.so\.1			  # C++
+NOSYMSORT	lib/sparcv9/libfru\.so\.1		  # C++
+NOSYMSORT	lib/sparcv9/libnsl\.so\.1		  # C++
+NOSYMSORT	lib/sparcv9/libsun_fc\.so\.1 		  # C++
+NOSYMSORT	opt/SUNWdtrt/tst/common/pid/tst.weak2.exe # DTrace test
+NOSYMSORT	usr/bin/audioconvert                      # C++
+NOSYMSORT	usr/bin/make                              # C++
+NOSYMSORT	usr/lib/amd64/libfru\.so\.1		  # C++
+NOSYMSORT	usr/lib/libfru\.so\.1                     # C++
+NOSYMSORT	usr/lib/libnisdb\.so\.2                   # C++
+NOSYMSORT	usr/lib/libsun_fc\.so\.1		  # C++
+NOSYMSORT	usr/lib/lms				  # C++
 
 
 # The libprtdiag_psr.so.1 objects built under usr/src/lib/libprtdiag_psr

--- a/usr/src/Makefile.master
+++ b/usr/src/Makefile.master
@@ -90,6 +90,8 @@ INTEL_BLD=      $(INTEL_BLD_1:i386=)
 # __GNUC64 indicates that the 64bit build should use the GNU C compiler.
 # There is no Sun C analogue.
 #
+# __GNUCNEXT enables options specific to the next version of GCC to be used
+#
 # The following version-specific options are operative regardless of which
 # compiler is primary, and control the versions of the given compilers to be
 # used.  They also allow compiler-version specific Makefile fragments.
@@ -98,6 +100,7 @@ INTEL_BLD=      $(INTEL_BLD_1:i386=)
 __SUNC=			$(POUND_SIGN)
 $(__SUNC)__GNUC=	$(POUND_SIGN)
 __GNUC64=		$(__GNUC)
+__GNUCNEXT=		$(POUND_SIGN)
 
 # Allow build-time "configuration" to enable or disable some things.
 # The default is POUND_SIGN, meaning "not enabled". If the environment
@@ -322,6 +325,9 @@ CC32BITCALLERS=		-_gcc=-massume-32bit-callers
 CCNOAUTOINLINE= -_gcc=-fno-inline-small-functions \
 	-_gcc=-fno-inline-functions-called-once \
 	-_gcc=-fno-ipa-cp
+
+$(__GNUCNEXT)CCNOAUTOINLINE += -_gcc=-fno-ipa-icf 
+$(__GNUCNEXT)CCNOAUTOINLINE += -_gcc=-fno-clone-functions
 
 # One optimization the compiler might perform is to turn this:
 #	#pragma weak foo

--- a/usr/src/tools/ctf/cvt/dwarf.c
+++ b/usr/src/tools/ctf/cvt/dwarf.c
@@ -1642,9 +1642,15 @@ die_variable_create(dwarf_t *dw, Dwarf_Die die, Dwarf_Off off, tdesc_t *tdp)
 	char *name;
 
 	debug(3, "die %llu: creating object definition\n", off);
+	name = die_name(dw, die);
 
-	if (die_isdecl(dw, die) || (name = die_name(dw, die)) == NULL)
-		return; /* skip prototypes and nameless objects */
+	/*
+	 * We used to skip variables that were die_isdecl() But GCC 7 emits
+	 * only these when a concrete definition follows an extern definition
+	 * in the same CU.
+	 */
+	if (name == NULL)
+		return;
 
 	ii = xcalloc(sizeof (iidesc_t));
 	ii->ii_type = die_isglobal(dw, die) ? II_GVAR : II_SVAR;

--- a/usr/src/uts/intel/io/dktp/controller/ata/ata_common.c
+++ b/usr/src/uts/intel/io/dktp/controller/ata/ata_common.c
@@ -3528,6 +3528,7 @@ ata_init_pm(dev_info_t *dip)
 	    "pm-components", pmc, 3) != DDI_PROP_SUCCESS) {
 		return;
 	}
+#endif
 
 	ata_ctlp->ac_pm_support = 1;
 	ata_ctlp->ac_pm_level = PM_LEVEL_D0;


### PR DESCRIPTION
Most importantly, this introduces the make variable __GNUCNEXT, in the manner of the old __GNUC4 to guard options that can't be passed to GCC 4 but must be passed to GCC 7

You would do:
```
export __GNUCNEXT=""
```

in your build environment file.

We then use this to pass -fno-clone-functions, which tidies up a lot of optimizer-induced pain.

Secondarily, it excepts more C++ gunk from the check_rtime dynsymsort checks.  There will still be check_rtime noise caused if your build machine finds the wrong runtime libraries, but no noise actually related to bad objects remains (I think).